### PR TITLE
Update HomeAssitantPlugin.cs - HttpClient Specify SSL Ver

### DIFF
--- a/HassioPlugin/HomeAssitantPlugin.cs
+++ b/HassioPlugin/HomeAssitantPlugin.cs
@@ -76,7 +76,7 @@ namespace HomeAssitantPlugin
             measure.path = api.ReadString("path", "state");
             measure.id = api.ReadString("entityId", "");
             measure.isInt = api.ReadString("isInt", "false").ToLower();
-            measure.server = api.ReadString("server", "homeassitant.local");
+            measure.server = api.ReadString("server", "homeassistant.local");
             measure.ssl = api.ReadString("ssl", "false").ToLower() == "true";
             measure.auth = api.ReadString("authKey", "");
             int port = api.ReadInt("port", -1);
@@ -95,7 +95,9 @@ namespace HomeAssitantPlugin
             {
                 if (measure.id.Equals(""))
                     return 0.0;
-                HttpClient client = new HttpClient();
+                var handler = new HttpClientHandler();
+                handler.SslProtocols = SslProtocols.Tls12 | SslProtocols.Tls13;
+                var client = new HttpClient(handler);
                 client.DefaultRequestHeaders.Add("Authorization", $"Bearer {measure.auth}");
                 Task<HttpResponseMessage> response = client.GetAsync($"{measure.fullUrl}/api/states/{measure.id}");
                 response.Wait();


### PR DESCRIPTION
- Specify SSL protocols (TLS 1.2 and 1.3) when creating HttpClient object to address SSL connection issues
- Fix typo in default server url
---
This fixes the issue I was having with the connection not working on SSL but it would without it. The connection would keep being closed. Still not sure of the exact reason but specifying the TLS versions when creating the HttpClient object seems to fix it.